### PR TITLE
Docs labeler config mix test

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,5 +5,5 @@
 docs:
 - all:
   - changed-files:
-    - any-glob-to-any-file: ['docs/**', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
-    - all-globs-to-any-file: '!docs/source/news/index.rst'
+    - any-glob-to-any-file: ['docs/source/**/*', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
+    - all-globs-to-all-files: ['!docs/source/news/*']

--- a/docs/source/news/index.rst
+++ b/docs/source/news/index.rst
@@ -2,3 +2,4 @@ News Index
 ==========
 
 This file lists all the news and updates related to the project.
+New line for testing issue 883.


### PR DESCRIPTION
This pull request updates the `.github/labeler.yml` file to refine file matching patterns for documentation-related labels and adds a test line to the `News Index` file.

Updates to file matching patterns:

* [`.github/labeler.yml`](diffhunk://#diff-a22c263686553013feaeb0677d26eeb0b8778a756c4311c1fce13384258026aaL8-R9): Adjusted glob patterns to better match documentation files. Specifically, refined `any-glob-to-any-file` to include all subdirectories under `docs/source` and updated `all-globs-to-all-files` to exclude files under `docs/source/news`.

Minor addition for testing:

* [`docs/source/news/index.rst`](diffhunk://#diff-41f7f4a2f852b292980904fb9892d5949bd9b6c967c0590e7debde63acabd623R5): Added a new line for testing purposes related to issue 883.