### PR TITLE
Labeler test 883

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,5 +5,5 @@
 docs:
 - all:
   - changed-files:
-    - any-glob-to-any-file: ['docs/source/news/*', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
+    - any-glob-to-any-file: ['docs/**', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
     - all-globs-to-all-file: '!docs/source/news/index.rst'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,4 +6,4 @@ docs:
 - all:
   - changed-files:
     - any-glob-to-any-file: ['docs/source/**/*', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
-    - all-globs-to-any-file: '!docs/source/news/*'
+    - all-globs-to-any-file: '!docs/source/news/index.rst'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,4 +6,4 @@ docs:
 - all:
   - changed-files:
     - any-glob-to-any-file: ['docs/**', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
-    - all-globs-to-any-file: ['!docs/source/news/*']
+    - all-globs-to-all-file: ['!docs/source/news/index.rst']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,4 +6,4 @@ docs:
 - all:
   - changed-files:
     - any-glob-to-any-file: ['docs/source/**/*', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
-    - all-globs-to-any-file: '!docs/source/news/index.rst'
+    - all-globs-to-all-file: '!docs/source/news/index.rst'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,5 +5,6 @@
 docs:
 - all:
   - changed-files:
-    - any-glob-to-any-file: ['docs/**', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
-    - all-globs-to-all-file: '!docs/source/news/index.rst'
+    - any-glob-to-any-file: ['docs/source/**/*', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
+    - all-globs-to-all-files: ['!docs/source/news/*']
+

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,4 +6,4 @@ docs:
 - all:
   - changed-files:
     - any-glob-to-any-file: ['docs/**', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
-    - all-globs-to-all-file: '!docs/source/news/index.rst'
+    - all-globs-to-all-file: ['!docs/source/news/index.rst']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,4 +6,4 @@ docs:
 - all:
   - changed-files:
     - any-glob-to-any-file: ['docs/**', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
-    - all-globs-to-all-file: ['!docs/source/news/index.rst']
+    - all-globs-to-all-file: '!docs/source/news/index.rst'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,4 +6,4 @@ docs:
 - all:
   - changed-files:
     - any-glob-to-any-file: ['docs/source/**/*', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
-    - all-globs-to-all-file: '!docs/source/news/*'
+    - all-globs-to-any-file: '!docs/source/news/*'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,5 +5,5 @@
 docs:
 - all:
   - changed-files:
-    - any-glob-to-any-file: ['docs/source/**/*', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
+    - any-glob-to-any-file: ['docs/**', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
     - all-globs-to-all-file: '!docs/source/news/index.rst'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,4 +6,4 @@ docs:
 - all:
   - changed-files:
     - any-glob-to-any-file: ['docs/**', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
-    - all-globs-to-all-file: '!docs/source/news/index.rst'
+    - all-globs-to-any-file: '!docs/source/news/index.rst'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,4 +6,4 @@ docs:
 - all:
   - changed-files:
     - any-glob-to-any-file: ['docs/source/**/*', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
-    - all-globs-to-all-file: ['!docs/source/news/index.rst']
+    - all-globs-to-any-file: '!docs/source/news/index.rst'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,5 +5,5 @@
 docs:
 - all:
   - changed-files:
-    - any-glob-to-any-file: ['docs/source/**/*', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
+    - any-glob-to-any-file: ['docs/source/**', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
     - all-globs-to-any-file: '!docs/source/news/index.rst'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,5 +5,5 @@
 docs:
 - all:
   - changed-files:
-    - any-glob-to-any-file: ['docs/source/**/', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
+    - any-glob-to-any-file: ['docs/source/news/*', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
     - all-globs-to-any-file: '!docs/source/news/index.rst'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,4 +6,4 @@ docs:
 - all:
   - changed-files:
     - any-glob-to-any-file: ['docs/**', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
-    - all-globs-to-any-file: '!docs/source/news/*'
+    - all-globs-to-any-file: '!docs/source/news/index.rst'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,5 +5,5 @@
 docs:
 - all:
   - changed-files:
-    - any-glob-to-any-file: ['docs/source/**', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
+    - any-glob-to-any-file: ['docs/source/**/', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
     - all-globs-to-any-file: '!docs/source/news/index.rst'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,4 +6,4 @@ docs:
 - all:
   - changed-files:
     - any-glob-to-any-file: ['docs/**', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
-    - all-globs-to-any-file: '!docs/source/news/index.rst'
+    - all-globs-to-all-file: ['!docs/source/news/*']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,4 +6,4 @@ docs:
 - all:
   - changed-files:
     - any-glob-to-any-file: ['docs/**', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
-    - all-globs-to-all-file: ['!docs/source/news/*']
+    - all-globs-to-any-file: '!docs/source/news/*'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,4 +6,4 @@ docs:
 - all:
   - changed-files:
     - any-glob-to-any-file: ['docs/**', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
-    - all-globs-to-all-file: ['!docs/source/news/index.rst']
+    - all-globs-to-any-file: '!docs/source/news/index.rst'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,5 +5,5 @@
 docs:
 - all:
   - changed-files:
-    - any-glob-to-any-file: ['docs/source/**/*', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
-    - all-globs-to-any-file: '!docs/source/news/index.rst'
+    - any-glob-to-any-file: ['docs/**', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
+    - all-globs-to-all-file: ['!docs/source/news/*']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,5 +5,5 @@
 docs:
 - all:
   - changed-files:
-    - any-glob-to-any-file: ['docs/**', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
-    - all-globs-to-any-file: '!docs/source/news/index.rst'
+    - any-glob-to-any-file: ['docs/source/**/*', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
+    - all-globs-to-all-file: '!docs/source/news/*'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,4 +6,4 @@ docs:
 - all:
   - changed-files:
     - any-glob-to-any-file: ['docs/**', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
-    - all-globs-to-all-file: ['!docs/source/news/*']
+    - all-globs-to-any-file: ['!docs/source/news/*']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,5 +5,5 @@
 docs:
 - all:
   - changed-files:
-    - any-glob-to-any-file: ['docs/source/**/*', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
+    - any-glob-to-any-file: ['docs/**', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
     - all-globs-to-any-file: '!docs/source/news/index.rst'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,5 +5,5 @@
 docs:
 - all:
   - changed-files:
-    - any-glob-to-any-file: ['docs/**', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
+    - any-glob-to-any-file: ['docs/source/**/*', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
     - all-globs-to-any-file: '!docs/source/news/index.rst'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,5 +5,5 @@
 docs:
 - all:
   - changed-files:
-    - any-glob-to-any-file: ['docs/**', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
-    - all-globs-to-any-file: '!docs/source/news/index.rst'
+    - any-glob-to-any-file: ['docs/source/**/*', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
+    - all-globs-to-all-file: ['!docs/source/news/index.rst']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,4 +6,4 @@ docs:
 - all:
   - changed-files:
     - any-glob-to-any-file: ['docs/source/news/*', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
-    - all-globs-to-any-file: '!docs/source/news/index.rst'
+    - all-globs-to-all-file: '!docs/source/news/index.rst'

--- a/docs/source/news/index.rst
+++ b/docs/source/news/index.rst
@@ -2,3 +2,4 @@ News Index
 ==========
 
 This file lists all the news and updates related to the project.
+sample test line


### PR DESCRIPTION
This pull request updates file labeling rules and makes a minor addition to the `News Index` file. The most important changes include refining glob patterns in `.github/labeler.yml` and adding a test line in `docs/source/news/index.rst`.

Updates to file labeling rules:

* [`.github/labeler.yml`](diffhunk://#diff-a22c263686553013feaeb0677d26eeb0b8778a756c4311c1fce13384258026aaL8-R9): Adjusted glob patterns for better specificity. The `any-glob-to-any-file` rule now includes all files under `docs/source`, and the `all-globs-to-all-file` rule excludes files under `docs/source/news`.

Minor addition to documentation:

* [`docs/source/news/index.rst`](diffhunk://#diff-41f7f4a2f852b292980904fb9892d5949bd9b6c967c0590e7debde63acabd623R5): Added a sample test line to the `News Index` file for testing purposes.